### PR TITLE
always return (x,y,z) coordinates, and set z to 0 if not specific in …

### DIFF
--- a/pyimzml/ImzMLParser.py
+++ b/pyimzml/ImzMLParser.py
@@ -164,7 +164,7 @@ class ImzMLParser:
             z = scan_elem.find('%scvParam[@accession="IMS:1000052"]' % self.sl).attrib["value"]
             self.coordinates.append((int(x), int(y), int(z)))
         except AttributeError:
-            self.coordinates.append((int(x), int(y)))
+            self.coordinates.append((int(x), int(y), 0))
 
     def __readimzmlmeta(self):
         """


### PR DESCRIPTION
If imzml file has x,y,z coordinates then  shape(imzml.coordinates) = [num spectra, 3], if just x,y then shape(imzml.coordinates) = [num spectra, 3].

This is annoying to work with programatically as I keep having to check for the presence of a z dimension. 

I propose to always return x,y,z coordinates, and set z to 0 if not specific in the file