### PR TITLE
Add support for ion mobility binary data array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ out
 gen
 # Created by .ignore support plugin (hsz.mobi)
 *.DS_Store
+
+# Prototype folder
+prototype/

--- a/pyimzml/ImzMLWriter.py
+++ b/pyimzml/ImzMLWriter.py
@@ -374,8 +374,13 @@ class ImzMLWriter(object):
 
         self._write_ibd(self.uuid.bytes)
 
-        self.wheezy_engine = Engine(loader=DictLoader({'imzml': IMZML_TEMPLATE}), extensions=[CoreExtension()])
-        self.imzml_template = self.wheezy_engine.get_template('imzml')
+        if self.include_mobility == False:
+            self.wheezy_engine = Engine(loader=DictLoader({'imzml': IMZML_TEMPLATE}), extensions=[CoreExtension()])
+            self.imzml_template = self.wheezy_engine.get_template('imzml')
+        elif self.include_mobility == True:
+            self.wheezy_engine = Engine(loader=DictLoader({'imzml': IMZML_MOBILITY_TEMPLATE}),
+                                        extensions=[CoreExtension()])
+            self.imzml_template = self.wheezy_engine.get_template('imzml')
         self.spectra = []
         self.first_mz = None
         self.hashes = defaultdict(list)  # mz_hash -> list of mz_data (disk location)
@@ -549,7 +554,7 @@ class ImzMLWriter(object):
         int_base = intensities[ix_max]
         int_tic = np.sum(intensities)
         if self.include_mobility == True:
-            s = _Spectrum(coords, mz_len, mz_offset, mz_enc_len, int_len, int_offset, int_enc_len, mob_len, mob_offset, mob_enc_len, mz_min, mz_max, mz_base, int_base, int_tic, userParams)
+            s = _Spectrum_Mobility(coords, mz_len, mz_offset, mz_enc_len, int_len, int_offset, int_enc_len, mob_len, mob_offset, mob_enc_len, mz_min, mz_max, mz_base, int_base, int_tic, userParams)
         elif self.include_mobility == False:
             s = _Spectrum(coords, mz_len, mz_offset, mz_enc_len, int_len, int_offset, int_enc_len, mz_min, mz_max, mz_base, int_base, int_tic, userParams)
         self.spectra.append(s)

--- a/pyimzml/ImzMLWriter.py
+++ b/pyimzml/ImzMLWriter.py
@@ -13,6 +13,134 @@ from wheezy.template import Engine, CoreExtension, DictLoader
 from pyimzml.compression import NoCompression, ZlibCompression
 
 IMZML_TEMPLATE = """\
+@require(uuid, sha1sum, mz_data_type, int_data_type, run_id, spectra, mode, obo_codes, obo_names, mz_compression, int_compression, polarity, spec_type, scan_direction, scan_pattern, scan_type, line_scan_direction)
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0_idx.xsd" version="1.1">
+  <cvList count="2">
+    <cv uri="http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" id="MS" version="3.65.0"/>
+    <cv uri="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/unit.obo" fullName="Unit Ontology" id="UO" version="12:10:2011"/>
+  </cvList>
+  <fileDescription>
+    <fileContent>
+      <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+      @if spec_type=='centroid':
+      <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+      @elif spec_type=='profile':
+      <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
+      @end
+      <cvParam cvRef="IMS" accession="IMS:@obo_codes[mode]" name="@mode" value=""/>
+      <cvParam cvRef="IMS" accession="IMS:1000080" name="universally unique identifier" value="@uuid"/>
+      <cvParam cvRef="IMS" accession="IMS:1000091" name="ibd SHA-1" value="@sha1sum"/>
+    </fileContent>
+  </fileDescription>
+  <referenceableParamGroupList count="4">
+    <referenceableParamGroup id="mzArray">
+      <cvParam cvRef="MS" accession="MS:@obo_codes[mz_compression]" name="@mz_compression" value=""/>
+      <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+      <cvParam cvRef="MS" accession="MS:@obo_codes[mz_data_type]" name="@mz_data_type" value=""/>
+      <cvParam cvRef="IMS" accession="IMS:1000101" name="external data" value="true"/>
+    </referenceableParamGroup>
+    <referenceableParamGroup id="intensityArray">
+      <cvParam cvRef="MS" accession="MS:@obo_codes[int_data_type]" name="@int_data_type" value=""/>
+      <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+      <cvParam cvRef="MS" accession="MS:@obo_codes[int_compression]" name="@int_compression" value=""/>
+      <cvParam cvRef="IMS" accession="IMS:1000101" name="external data" value="true"/>
+    </referenceableParamGroup>
+    <referenceableParamGroup id="scan1">
+      <cvParam cvRef="MS" accession="MS:1000093" name="increasing m/z scan"/>
+      <cvParam cvRef="MS" accession="MS:1000512" name="filter string" value=""/>
+    </referenceableParamGroup>
+    <referenceableParamGroup id="spectrum1">
+      <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+      <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="0"/>
+      @if spec_type=='centroid':
+      <cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" value=""/>
+      @elif spec_type=='profile':
+      <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
+      @end
+      @if polarity=='positive':
+      <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+      @elif polarity=='negative':
+      <cvParam cvRef="MS" accession="MS:1000129" name="negative scan" value=""/>
+      @end
+    </referenceableParamGroup>
+  </referenceableParamGroupList>
+  <softwareList count="1">
+    <software id="pyimzml" version="0.0001">
+      <cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="pyimzml exporter"/>
+    </software>
+  </softwareList>
+  <scanSettingsList count="1">
+    <scanSettings id="scanSettings1">
+      <cvParam cvRef="IMS" accession="IMS:@obo_codes[scan_direction]" name="@obo_names[scan_direction]"/>
+      <cvParam cvRef="IMS" accession="IMS:@obo_codes[scan_pattern]" name="@obo_names[scan_pattern]"/>
+      <cvParam cvRef="IMS" accession="IMS:@obo_codes[scan_type]" name="@obo_names[scan_type]"/>
+      <cvParam cvRef="IMS" accession="IMS:@obo_codes[line_scan_direction]" name="@obo_names[line_scan_direction]"/>
+      <cvParam cvRef="IMS" accession="IMS:1000042" name="max count of pixels x" value="@{(max(s.coords[0] for s in spectra))!!s}"/>
+      <cvParam cvRef="IMS" accession="IMS:1000043" name="max count of pixels y" value="@{(max(s.coords[1] for s in spectra))!!s}"/>
+    </scanSettings>
+  </scanSettingsList>
+  <instrumentConfigurationList count="1">
+    <instrumentConfiguration id="IC1">
+    </instrumentConfiguration>
+  </instrumentConfigurationList>
+  <dataProcessingList count="1">
+    <dataProcessing id="export_from_pyimzml">
+      <processingMethod order="0" softwareRef="pyimzml">
+        <cvParam cvRef="MS" accession="MS:1000530" name="file format conversion" value="Output to imzML"/>
+      </processingMethod>
+    </dataProcessing>
+  </dataProcessingList>
+  <run defaultInstrumentConfigurationRef="IC1" id="@run_id">
+    <spectrumList count="@{len(spectra)!!s}" defaultDataProcessingRef="export_from_pyimzml">
+      @for index, s in enumerate(spectra):
+      <spectrum defaultArrayLength="0" id="spectrum=@{(index+1)!!s}" index="@{(index+1)!!s}">
+        <referenceableParamGroupRef ref="spectrum1"/>
+        <cvParam cvRef="MS" accession="MS:1000528" name="lowest observed m/z" value="@{s.mz_min!!s}" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+        <cvParam cvRef="MS" accession="MS:1000527" name="highest observed m/z" value="@{s.mz_max!!s}" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+        <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="@{s.mz_base!!s}" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+        <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="@{s.int_base!!s}" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of counts"/>
+        <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="@{s.int_tic!!s}"/>
+        <scanList count="1">
+          <cvParam accession="MS:1000795" cvRef="MS" name="no combination"/>
+          <scan instrumentConfigurationRef="instrumentConfiguration0">
+            <referenceableParamGroupRef ref="scan1"/>
+            <cvParam accession="IMS:1000050" cvRef="IMS" name="position x" value="@{s.coords[0]!!s}"/>
+            <cvParam accession="IMS:1000051" cvRef="IMS" name="position y" value="@{s.coords[1]!!s}"/>
+            @if len(s.coords) == 3:
+            <cvParam accession="IMS:1000052" cvRef="IMS" name="position z" value="@{s.coords[2]!!s}"/>
+            @end
+            @if s.userParams:
+                @for up in s.userParams:
+                <userParam name="@up['name']" value="@up['value']"/> 
+                @end
+            @end
+          </scan>
+        </scanList>
+        <binaryDataArrayList count="2">
+          <binaryDataArray encodedLength="0">
+            <referenceableParamGroupRef ref="mzArray"/>
+            <cvParam accession="IMS:1000103" cvRef="IMS" name="external array length" value="@{s.mz_len!!s}"/>
+            <cvParam accession="IMS:1000104" cvRef="IMS" name="external encoded length" value="@{s.mz_enc_len!!s}"/>
+            <cvParam accession="IMS:1000102" cvRef="IMS" name="external offset" value="@{s.mz_offset!!s}"/>
+            <binary/>
+          </binaryDataArray>
+          <binaryDataArray encodedLength="0">
+            <referenceableParamGroupRef ref="intensityArray"/>
+            <cvParam accession="IMS:1000103" cvRef="IMS" name="external array length" value="@{s.int_len!!s}"/>
+            <cvParam accession="IMS:1000104" cvRef="IMS" name="external encoded length" value="@{s.int_enc_len!!s}"/>
+            <cvParam accession="IMS:1000102" cvRef="IMS" name="external offset" value="@{s.int_offset!!s}"/>
+            <binary/>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+      @end
+    </spectrumList>
+  </run>
+</mzML>
+"""
+
+IMZML_MOBILITY_TEMPLATE = """\
 @require(uuid, sha1sum, mz_data_type, int_data_type, mob_data_type, run_id, spectra, mode, obo_codes, obo_names, mz_compression, int_compression, mob_compression, polarity, spec_type, scan_direction, scan_pattern, scan_type, line_scan_direction)
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0_idx.xsd" version="1.1">
@@ -170,7 +298,9 @@ class _MaxlenDict(OrderedDict):
             self.popitem(0) #pop oldest
         OrderedDict.__setitem__(self, key, value)
 
-_Spectrum = namedtuple('_Spectrum', 'coords mz_len mz_offset mz_enc_len int_len int_offset int_enc_len mob_len mob_offset mob_enc_len mz_min mz_max mz_base int_base int_tic userParams') #todo: change named tuple to dict and parse xml template properly (i.e. remove hardcoding so parameters can be optional)
+_Spectrum = namedtuple('_Spectrum', 'coords mz_len mz_offset mz_enc_len int_len int_offset int_enc_len mz_min mz_max mz_base int_base int_tic userParams') #todo: change named tuple to dict and parse xml template properly (i.e. remove hardcoding so parameters can be optional)
+
+_Spectrum_Mobility = namedtuple('_Spectrum_Mobility', 'coords mz_len mz_offset mz_enc_len int_len int_offset int_enc_len mob_len mob_offset mob_enc_len mz_min mz_max mz_base int_base int_tic userParams') #todo: change named tuple to dict and parse xml template properly (i.e. remove hardcoding so parameters can be optional)
 
 class ImzMLWriter(object):
     """
@@ -197,6 +327,10 @@ class ImzMLWriter(object):
             How to compress the mz array data before saving
         :param mobility_compression:
             How to compress the mobility array data before saving
+        :param include_mobility:
+            bool: True or False
+            Whether imzML schema should include trapped ion mobility spectrometry data. Units/metadata based
+            on Bruker TIMS data.
     """
     def __init__(self, output_filename,
                  mz_dtype=np.float64,
@@ -211,7 +345,11 @@ class ImzMLWriter(object):
                  mz_compression=NoCompression(),
                  intensity_compression=NoCompression(),
                  mobility_compression=NoCompression(),
-                 polarity=None):
+                 polarity=None,
+                 include_mobility=False):
+
+        # Whether to include ion mobility data.
+        self.include_mobility = include_mobility
 
         self.mz_dtype = mz_dtype
         self.intensity_dtype = intensity_dtype
@@ -264,7 +402,8 @@ class ImzMLWriter(object):
         spectra = self.spectra
         mz_data_type = self._np_type_to_name(self.mz_dtype)
         int_data_type = self._np_type_to_name(self.intensity_dtype)
-        mob_data_type = self._np_type_to_name(self.mobility_dtype)
+        if self.include_mobility == True:
+            mob_data_type = self._np_type_to_name(self.mobility_dtype)
         obo_codes = {"32-bit integer": "1000519", 
                      "16-bit float": "1000520",
                      "32-bit float": "1000521",
@@ -311,7 +450,8 @@ class ImzMLWriter(object):
         spec_type = self.spec_type
         mz_compression = self.mz_compression.name
         int_compression = self.intensity_compression.name
-        mob_compression = self.mobility_compression.name
+        if self.include_mobility == True:
+            mob_compression = self.mobility_compression.name
         polarity = self.polarity
         scan_direction = self.scan_direction
         scan_pattern = self.scan_pattern
@@ -362,7 +502,7 @@ class ImzMLWriter(object):
         self.lru_cache[mzs] = mz_data
         return mz_data
 
-    def addSpectrum(self, mzs, intensities, mobilities, coords, userParams=[]):
+    def addSpectrum(self, mzs, intensities, coords, mobilities=None, userParams=[]):
         """
         Add a mass spectrum to the file.
 
@@ -384,7 +524,8 @@ class ImzMLWriter(object):
         if self.mode != "continuous" or self.first_mz is None:
             mzs = self.mz_compression.rounding(mzs)
         intensities = self.intensity_compression.rounding(intensities)
-        mobilities = self.mobility_compression.rounding(mobilities)
+        if self.include_mobility == False:
+            mobilities = self.mobility_compression.rounding(mobilities)
 
         if self.mode == "continuous":
             if self.first_mz is None:
@@ -399,14 +540,18 @@ class ImzMLWriter(object):
         mz_offset, mz_len, mz_enc_len = mz_data
 
         int_offset, int_len, int_enc_len = self._encode_and_write(intensities, self.intensity_dtype, self.intensity_compression)
-        mob_offset, mob_len, mob_enc_len = self._encode_and_write(mobilities, self.mobility_dtype, self.mobility_compression)
+        if self.include_mobility == False:
+            mob_offset, mob_len, mob_enc_len = self._encode_and_write(mobilities, self.mobility_dtype, self.mobility_compression)
         mz_min = np.min(mzs)
         mz_max = np.max(mzs)
         ix_max = np.argmax(intensities)
         mz_base = mzs[ix_max]
         int_base = intensities[ix_max]
         int_tic = np.sum(intensities)
-        s = _Spectrum(coords, mz_len, mz_offset, mz_enc_len, int_len, int_offset, int_enc_len, mob_len, mob_offset, mob_enc_len, mz_min, mz_max, mz_base, int_base, int_tic, userParams)
+        if self.include_mobility == True:
+            s = _Spectrum(coords, mz_len, mz_offset, mz_enc_len, int_len, int_offset, int_enc_len, mob_len, mob_offset, mob_enc_len, mz_min, mz_max, mz_base, int_base, int_tic, userParams)
+        elif self.include_mobility == False:
+            s = _Spectrum(coords, mz_len, mz_offset, mz_enc_len, int_len, int_offset, int_enc_len, mz_min, mz_max, mz_base, int_base, int_tic, userParams)
         self.spectra.append(s)
 
     def close(self):  # 'close' is a more common use for this
@@ -454,15 +599,31 @@ def _main(argv):
         raise IOError('input file not specified')
     if outputfile=='':
         outputfile=inputfile+'.imzML'
-    imzml = ImzMLParser(inputfile)
+    imzml = ImzMLParser(inputfile, include_mobility=False)
+    spectra = []
+    with ImzMLWriter(outputfile, mz_dtype=np.float32, intensity_dtype=np.float32) as writer:
+        for i, coords in enumerate(imzml.coordinates):
+            mzs, intensities = imzml.getspectrum(i)
+            writer.addSpectrum(mzs, intensities, coords)
+            spectra.append((mzs, intensities, coords))
+
+    imzml = ImzMLParser(outputfile, include_mobility=False)
+    spectra2 = []
+    for i, coords in enumerate(imzml.coordinates):
+        mzs, intensities = imzml.getspectrum(i)
+        spectra2.append((mzs, intensities, coords))
+
+    print(spectra[0] == spectra2[0])
+
+    imzml = ImzMLParser(inputfile, include_mobility=True)
     spectra = []
     with ImzMLWriter(outputfile, mz_dtype=np.float32, intensity_dtype=np.float32) as writer:
         for i, coords in enumerate(imzml.coordinates):
             mzs, intensities, mobilities = imzml.getspectrum(i)
-            writer.addSpectrum(mzs, intensities, mobilities, coords)
+            writer.addSpectrum(mzs, intensities, coords, mobilities=mobilities)
             spectra.append((mzs, intensities, mobilities, coords))
 
-    imzml = ImzMLParser(outputfile)
+    imzml = ImzMLParser(outputfile, include_mobility=True)
     spectra2 = []
     for i, coords in enumerate(imzml.coordinates):
         mzs, intensities, mobilities = imzml.getspectrum(i)

--- a/pyimzml/ImzMLWriter.py
+++ b/pyimzml/ImzMLWriter.py
@@ -601,7 +601,7 @@ def _main(argv):
         outputfile=inputfile+'.imzML'
     imzml = ImzMLParser(inputfile, include_mobility=False)
     spectra = []
-    with ImzMLWriter(outputfile, mz_dtype=np.float32, intensity_dtype=np.float32) as writer:
+    with ImzMLWriter(outputfile, mz_dtype=np.float32, intensity_dtype=np.float32, include_mobility=False) as writer:
         for i, coords in enumerate(imzml.coordinates):
             mzs, intensities = imzml.getspectrum(i)
             writer.addSpectrum(mzs, intensities, coords)
@@ -617,7 +617,7 @@ def _main(argv):
 
     imzml = ImzMLParser(inputfile, include_mobility=True)
     spectra = []
-    with ImzMLWriter(outputfile, mz_dtype=np.float32, intensity_dtype=np.float32) as writer:
+    with ImzMLWriter(outputfile, mz_dtype=np.float32, intensity_dtype=np.float32, include_mobility=True) as writer:
         for i, coords in enumerate(imzml.coordinates):
             mzs, intensities, mobilities = imzml.getspectrum(i)
             writer.addSpectrum(mzs, intensities, coords, mobilities=mobilities)

--- a/pyimzml/ImzMLWriter.py
+++ b/pyimzml/ImzMLWriter.py
@@ -178,7 +178,7 @@ IMZML_MOBILITY_TEMPLATE = """\
     </referenceableParamGroup>
     <referenceableParamGroup id="mobilityArray">
       <cvParam cvRef="MS" accession="MS:@obo_codes[mob_compression]" name="@mob_compression" value=""/>
-      <cvParam cvRef="MS" accession="MS:1002893" name="ion mobility array" unitCvRef="MS" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
+      <cvParam cvRef="MS" accession="MS:1003006" name="mean inverse reduced ion mobility array" unitCvRef="MS" unitAccession="MS:1002814" unitName="volt-second per square centimeter"/>
       <cvParam cvRef="MS" accession="MS:@obo_codes[mob_data_type]" name="@mob_data_type" value=""/>
       <cvParam cvRef="IMS" accession="IMS:1000101" name="external data" value="true"/>
     </referenceableParamGroup>

--- a/pyimzml/ImzMLWriter.py
+++ b/pyimzml/ImzMLWriter.py
@@ -540,7 +540,7 @@ class ImzMLWriter(object):
         mz_offset, mz_len, mz_enc_len = mz_data
 
         int_offset, int_len, int_enc_len = self._encode_and_write(intensities, self.intensity_dtype, self.intensity_compression)
-        if self.include_mobility == False:
+        if self.include_mobility == True:
             mob_offset, mob_len, mob_enc_len = self._encode_and_write(mobilities, self.mobility_dtype, self.mobility_compression)
         mz_min = np.min(mzs)
         mz_max = np.max(mzs)


### PR DESCRIPTION
Added support for third binary data array in ImzMLWriter and ImzMLParser to house trapped ion mobility spectrometry (TIMS) data from Bruker timsTOF instruments.