### PR TITLE
Fix a bug in parsing userParam value

### DIFF
--- a/pyimzml/metadata.py
+++ b/pyimzml/metadata.py
@@ -169,7 +169,7 @@ class ParamGroup:
             name = node.get('name')
             dtype = node.get('dtype')
             raw_value = node.get('value')
-            parsed_value = convert_xml_value(raw_value, dtype)
+            parsed_value = convert_xml_value(dtype, raw_value)
             unit_accession = node.get('unitAccession')
             unit_name = convert_term_name(unit_accession)
             self.user_params.append(

--- a/pyimzml/ontology/ontology.py
+++ b/pyimzml/ontology/ontology.py
@@ -44,7 +44,7 @@ def convert_xml_value(dtype, value):
             return DTYPE_MAPPING[dtype](value)
         elif value is None or value == '':
             # Many cv_params are flags and have either a None or empty-string value.
-            # Replace their value with True in these cases, so their existance isn't so ambiguous.
+            # Replace their value with True in these cases, so their existence isn't so ambiguous.
             return True
         else:
             return value


### PR DESCRIPTION
When calling the function `convert_xml_value` in one of the places, the order of arguments was reversed.
Thanks @ZhengnanCheng for the bug reporting